### PR TITLE
fix: Improve release version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,24 @@
 REPO_NAME=kubectl-bindrole
 PKGROOT=github.com/Ladicle/kubectl-bindrole
-VERSION ?= $(shell git rev-parse --short HEAD)
+VERSION ?= $(shell git describe --abbrev=0 --tags)
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
 OUTDIR=_output
 
 build:
-	GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME)" -o $(OUTDIR)/kubectl-bindrole
+	GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME) -X $(PKGROOT)/cmd.commit=$(GIT_COMMIT)" -o $(OUTDIR)/kubectl-bindrole
 
 build-linux:
-	GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME)" -o $(OUTDIR)/kubectl-bindrole_linux-amd64/kubectl-bindrole
+	GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME) -X $(PKGROOT)/cmd.commit=$(GIT_COMMIT)" -o $(OUTDIR)/kubectl-bindrole_linux-amd64/kubectl-bindrole
 
 build-darwin:
-	GO111MODULE=on GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME)" -o $(OUTDIR)/kubectl-bindrole_darwin-amd64/kubectl-bindrole
+	GO111MODULE=on GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME) -X $(PKGROOT)/cmd.commit=$(GIT_COMMIT)" -o $(OUTDIR)/kubectl-bindrole_darwin-amd64/kubectl-bindrole
 
 build-windows:
-	GO111MODULE=on GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME)" -o $(OUTDIR)/kubectl-bindrole_windows-amd64/kubectl-bindrole
+	GO111MODULE=on GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME) -X $(PKGROOT)/cmd.commit=$(GIT_COMMIT)" -o $(OUTDIR)/kubectl-bindrole_windows-amd64/kubectl-bindrole
 
 
 install:
-	GO111MODULE=on CGO_ENABLED=0 go install -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME)"
+	GO111MODULE=on CGO_ENABLED=0 go install -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME) -X $(PKGROOT)/cmd.commit=$(GIT_COMMIT)"
 check:
 	GO111MODULE=on go vet $(PKGROOT)/...
 	./test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO_NAME=kubectl-bindrole
 PKGROOT=github.com/Ladicle/kubectl-bindrole
-VERSION ?= $(shell git describe --abbrev=0 --tags)
+VERSION ?= $(shell git describe --abbrev=0 --tags 2>/dev/null || echo no-version)
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 OUTDIR=_output
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -21,6 +21,7 @@ var (
 	// set values via build flags
 	command string
 	version string
+	commit  string
 
 	subkind string
 	verflag bool
@@ -37,7 +38,7 @@ func Execute() error {
 	pflag.Parse()
 
 	if verflag {
-		fmt.Printf("%v - %v", command, version)
+		fmt.Printf("%v - %v - %v", command, version, commit)
 		return nil
 	}
 	if pflag.NArg() != 1 {


### PR DESCRIPTION
*What would you like to be added*:

Currently, the command version output displays git commit yet release version is required. 

This fix/enhancement was trying to improve version output with release version as well as commit log