### PR TITLE
Remove no longer unused package

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/Ladicle/kubectl-bindrole/cmd"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {


### PR DESCRIPTION
`cmd/cmd.go` imports all authentication plugins at once.