### PR TITLE
Setup GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,14 @@
+name: "Test kubectl-bindrole using KinD"
+on: [pull_request, push]
+jobs:
+  kind:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: engineerd/setup-kind@v0.1.0
+    - name: Build kubectl-bindrole
+      run: make build
+    - name: Run test.sh
+      run: |
+        export KUBECONFIG="$(kind get kubeconfig-path)"
+        ./test.sh

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,10 @@ build-windows:
 
 install:
 	GO111MODULE=on CGO_ENABLED=0 go install -ldflags "-w -X $(PKGROOT)/cmd.version=$(VERSION) -X $(PKGROOT)/cmd.command=$(REPO_NAME) -X $(PKGROOT)/cmd.commit=$(GIT_COMMIT)"
+
 check:
 	GO111MODULE=on go vet $(PKGROOT)/...
-	./test
+	./test.sh
 
 .PHONY: clean
 clean:

--- a/test.sh
+++ b/test.sh
@@ -1,24 +1,5 @@
 #!/bin/bash -eu
 
-echo "Building binary..."
-go build
-
-minikubeStatus=$(sudo sudo minikube status|grep Running|wc -l)
-if [ $minikubeStatus != 3 ]; then
-    echo "minikube is not running :("
-    exit 1
-fi
-
-function cleanup() {
-    echo; echo "Cleaning up!"
-    kubectl delete sa test-user || :
-    kubectl delete psp test-psp || :
-    kubectl delete role test-role || :
-    kubectl delete rolebinding test || :
-    kubectl delete clusterrolebinding test || :
-}
-trap cleanup EXIT
-
 echo; echo "Creating ServiceAccount..."
 kubectl create sa test-user
 
@@ -79,7 +60,4 @@ echo; echo "Binding ClusterRole..."
 kubectl create clusterrolebinding test --clusterrole edit --serviceaccount default:test-user
 
 echo; echo "Test..."
-./kubectl-bindrole test-user
-
-echo; echo "Roles via kubectl..."
-kubectl describe clusterrole edit|grep '\[\]'|sort
+./_output/kubectl-bindrole test-user


### PR DESCRIPTION
This PR setups GitHub Actions workflow for CI. For the workflow, I replaced KinD as a test cluster instead of minikube.