### PR TITLE
Copy LICENSE file to distribution package

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,6 +11,7 @@ make build-windows
 # compose binaries
 cd _output/
 for dir in $(find . -type d -name "kubectl-bindrole_*"); do
+    cp ../LICENSE $dir
     tar -zcvf $dir.tar.gz $dir
 done
 


### PR DESCRIPTION
Pack LICENSE file to distribution package because it needs for krew.