### PR TITLE
Rename command from kubectl-bindrole to kubectl-rolesum

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: "Test kubectl-bindrole using KinD"
+name: "Test kubectl-rolesum using KinD"
 on: [pull_request, push]
 jobs:
   kind:
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: engineerd/setup-kind@v0.1.0
-    - name: Build kubectl-bindrole
+    - name: Build kubectl-rolesum
       run: make build
     - name: Run test.sh
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-PKGROOT=github.com/Ladicle/kubectl-bindrole
+PKGROOT=github.com/Ladicle/kubectl-rolesum
 
-CMD=kubectl-bindrole
+CMD=kubectl-rolesum
 VERSION ?= $(shell git describe --abbrev=0 --tags 2>/dev/null || echo no-version)
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# kubectl-bindrole
+# kubectl-rolesum
 
 Summarize RBAC roles for the specified subject (ServiceAccount, User and Group).
+
+:warning: **kubectl-bindrole is renamed to kubectl-rolesum.**
 
 ![screenshot](./img/screenshot.png)
 
@@ -8,32 +10,32 @@ Summarize RBAC roles for the specified subject (ServiceAccount, User and Group).
 
 ### for macOS
 
-bindrole supports [homebrew](https://docs.brew.sh/Installation) :beer:
+rolesum supports [homebrew](https://docs.brew.sh/Installation) :beer:
 
 ```
-brew install Ladicle/kubectl-bindrole/kubectl-bindrole
+brew install Ladicle/kubectl-rolesum/kubectl-rolesum
 ```
 
 ### for other devices
 
-The easiest way is to download binary from the [release page](https://github.com/Ladicle/kubectl-bindrole/releases).
+The easiest way is to download binary from the [release page](https://github.com/Ladicle/kubectl-rolesum/releases).
 You can also download this repository and install it using Makefile.
 
 ## Usage
 
 ```bash
-$ kubectl bindrole -h  # or kubectl-bindrole -h
+$ kubectl rolesum -h  # or kubectl-rolesum -h
 Summarize RBAC roles for the specified subject
 
 Usage:
-  kubectl bindrole [options] <SubjectName>
+  kubectl rolesum [options] <SubjectName>
 
 Examples:
-  # Summarize roles tied to the "ci-bot" ServiceAccount.
-  kubectl bindrole ci-bot
+  # Summarize roles bound to the "ci-bot" ServiceAccount.
+  kubectl rolesum ci-bot
 
-  # Summarize roles tied to the "developer" Group.
-  kubectl bindrole -k Group developer
+  # Summarize roles bound to the "developer" Group.
+  kubectl rolesum -k Group developer
 
 SubjectKinds:
   - ServiceAccount (default)
@@ -47,7 +49,7 @@ Options:
   -o, --options                List of all options for this command
       --version                Show version for this command
 
-Use "kubectl bindrole --options" for a list of all options (applies to this command).
+Use "kubectl rolesum --options" for a list of all options (applies to this command).
 ```
 
 This command supports both kubectl-plugin mode and standalone mode.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,10 +17,10 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	"github.com/Ladicle/kubectl-bindrole/pkg/explorer"
-	brcmdutil "github.com/Ladicle/kubectl-bindrole/pkg/util/cmd"
-	"github.com/Ladicle/kubectl-bindrole/pkg/util/printer"
-	"github.com/Ladicle/kubectl-bindrole/pkg/util/subject"
+	"github.com/Ladicle/kubectl-rolesum/pkg/explorer"
+	brcmdutil "github.com/Ladicle/kubectl-rolesum/pkg/util/cmd"
+	"github.com/Ladicle/kubectl-rolesum/pkg/util/printer"
+	"github.com/Ladicle/kubectl-rolesum/pkg/util/subject"
 )
 
 var (
@@ -29,13 +29,13 @@ var (
 	version string
 	commit  string
 
-	bindroleExample = fmt.Sprintf(`%v
-kubectl bindrole ci-bot
+	rolesumExample = fmt.Sprintf(`%v
+kubectl rolesum ci-bot
 
 %v
-kubectl bindrole -k Group developer`,
-		aurora.BrightBlack("# Summarize roles tied to the \"ci-bot\" ServiceAccount."),
-		aurora.BrightBlack("# Summarize roles tied to the \"developer\" Group."))
+kubectl rolesum -k Group developer`,
+		aurora.BrightBlack("# Summarize roles bound to the \"ci-bot\" ServiceAccount."),
+		aurora.BrightBlack("# Summarize roles bound to the \"developer\" Group."))
 )
 
 type Option struct {
@@ -46,10 +46,10 @@ type Option struct {
 	f cmdutil.Factory
 }
 
-func NewBindroleCmd() *cobra.Command {
+func NewRolesumCmd() *cobra.Command {
 	opt := Option{}
 	cmd := &cobra.Command{
-		Use: fmt.Sprintf("bindrole [options] <%v>",
+		Use: fmt.Sprintf("rolesum [options] <%v>",
 			aurora.Yellow("SubjectName")),
 		Version:               version,
 		DisableFlagsInUseLine: true,
@@ -57,7 +57,7 @@ func NewBindroleCmd() *cobra.Command {
 		SilenceErrors:         true,
 		Short:                 "Summarize RBAC roles for the specified subject",
 		Long:                  "Summarize RBAC roles for the specified subject",
-		Example:               templates.Examples(bindroleExample),
+		Example:               templates.Examples(rolesumExample),
 		Run: func(cmd *cobra.Command, args []string) {
 			brcmdutil.CheckErr(opt.Validate(cmd, args))
 			brcmdutil.CheckErr(opt.Run())

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Ladicle/kubectl-bindrole
+module github.com/Ladicle/kubectl-rolesum
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -3,16 +3,16 @@ package main
 import (
 	"github.com/spf13/pflag"
 
-	"github.com/Ladicle/kubectl-bindrole/cmd"
-	cmdutil "github.com/Ladicle/kubectl-bindrole/pkg/util/cmd"
+	"github.com/Ladicle/kubectl-rolesum/cmd"
+	cmdutil "github.com/Ladicle/kubectl-rolesum/pkg/util/cmd"
 )
 
 func init() {
-	flags := pflag.NewFlagSet("kubectl-bindrole", pflag.ExitOnError)
+	flags := pflag.NewFlagSet("kubectl-rolesum", pflag.ExitOnError)
 	pflag.CommandLine = flags
 }
 
 func main() {
-	command := cmd.NewBindroleCmd()
+	command := cmd.NewRolesumCmd()
 	cmdutil.CheckErr(command.Execute())
 }

--- a/pkg/explorer/subjutil.go
+++ b/pkg/explorer/subjutil.go
@@ -5,7 +5,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/Ladicle/kubectl-bindrole/pkg/util/subject"
+	"github.com/Ladicle/kubectl-rolesum/pkg/util/subject"
 )
 
 // subjectRoles retrieve RoleBindings for the specified subject.

--- a/pkg/util/cmd/error.go
+++ b/pkg/util/cmd/error.go
@@ -12,6 +12,6 @@ func CheckErr(err error) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, " %v Error: %v.\n", aurora.Red(">"), err)
-	fmt.Fprintf(os.Stderr, " %v Run %v command for the usage.\n", aurora.Red(">"), aurora.Yellow("kubectl bindrole -h"))
+	fmt.Fprintf(os.Stderr, " %v Run %v command for the usage.\n", aurora.Red(">"), aurora.Yellow("kubectl rolesum -h"))
 	os.Exit(1)
 }

--- a/pkg/util/cmd/usage.go
+++ b/pkg/util/cmd/usage.go
@@ -31,7 +31,7 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
   -o, --options                List of all options for this command
       --version                Show version for this command
 
-Use "kubectl bindrole --options" for a list of all options (applies to this command).
+Use "kubectl rolesum --options" for a list of all options (applies to this command).
 `,
 	aurora.Cyan("Usage"),
 	aurora.Cyan("Aliases"),

--- a/pkg/util/printer/converter.go
+++ b/pkg/util/printer/converter.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/logrusorgru/aurora"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 
-	"github.com/Ladicle/kubectl-bindrole/pkg/explorer"
+	"github.com/Ladicle/kubectl-rolesum/pkg/explorer"
 )
 
 const (

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -11,8 +11,8 @@ import (
 	policy "k8s.io/api/policy/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
 
-	"github.com/Ladicle/kubectl-bindrole/pkg/explorer"
-	"github.com/Ladicle/kubectl-bindrole/pkg/util/subject"
+	"github.com/Ladicle/kubectl-rolesum/pkg/explorer"
+	"github.com/Ladicle/kubectl-rolesum/pkg/util/subject"
 )
 
 type PrettyPrinter struct {
@@ -42,7 +42,7 @@ func (p *PrettyPrinter) PrintSA(sa *core.ServiceAccount) {
 	}
 }
 
-func (p *PrettyPrinter) PrintBindRoles(sbjrs []*explorer.SubjectRole) {
+func (p *PrettyPrinter) PrintRolesums(sbjrs []*explorer.SubjectRole) {
 	for _, r := range sbjrs {
 		fmt.Fprintf(p.out, "%v %v/%v\n", bullet, blank2Asterisk(r.Namespace), r.Name)
 	}

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ make build-windows
 
 # compose binaries
 cd _output/
-for dir in $(find . -type d -name "kubectl-bindrole_*"); do
+for dir in $(find . -type d -name "kubectl-rolesum_*"); do
     cp ../LICENSE $dir
     tar -zcvf $dir.tar.gz $dir
 done

--- a/test.sh
+++ b/test.sh
@@ -60,4 +60,4 @@ echo; echo "Binding ClusterRole..."
 kubectl create clusterrolebinding test --clusterrole edit --serviceaccount default:test-user
 
 echo; echo "Test..."
-./_output/kubectl-bindrole test-user
+./_output/kubectl-rolesum test-user


### PR DESCRIPTION
The `bindrole` is not a good name because this command does not actually bind roles. That's why this command is renamed to `rolesum`.