### PR TITLE
added details about the bindings to the output

### DIFF
--- a/pkg/explorer/explorer.go
+++ b/pkg/explorer/explorer.go
@@ -20,9 +20,13 @@ func NewPolicyExplorer(client *kubernetes.Clientset) *PolicyExplorer {
 }
 
 type SubjectRole struct {
-	Name       string
-	Namespace  string
-	PolicyList *SubjectPolicyList
+	BindingName      string
+	BindingNamespace string
+	BindingType      string
+	Name             string
+	Namespace        string
+	Type             string
+	PolicyList       *SubjectPolicyList
 }
 
 type SubjectPolicyList struct {
@@ -56,9 +60,13 @@ func (e *PolicyExplorer) NamespacedSbjRoles(sbj *rbacv1.Subject) ([]*SubjectRole
 			}
 
 			sbjrs = append(sbjrs, &SubjectRole{
-				Name:       role.Name,
-				Namespace:  role.Namespace,
-				PolicyList: sbjpl,
+				BindingName:      b.Name,
+				BindingNamespace: b.Namespace,
+				BindingType:      "RB",
+				Name:             role.Name,
+				Namespace:        role.Namespace,
+				Type:             "CR",
+				PolicyList:       sbjpl,
 			})
 		} else if b.RoleRef.Kind == "Role" {
 			role, err := e.client.RbacV1().Roles(sbj.Namespace).
@@ -75,9 +83,13 @@ func (e *PolicyExplorer) NamespacedSbjRoles(sbj *rbacv1.Subject) ([]*SubjectRole
 			}
 
 			sbjrs = append(sbjrs, &SubjectRole{
-				Name:       role.Name,
-				Namespace:  role.Namespace,
-				PolicyList: sbjpl,
+				BindingName:      b.Name,
+				BindingNamespace: b.Namespace,
+				BindingType:      "RB",
+				Name:             role.Name,
+				Namespace:        role.Namespace,
+				Type:             "R",
+				PolicyList:       sbjpl,
 			})
 		}
 	}
@@ -102,9 +114,13 @@ func (e *PolicyExplorer) ClusterSbjRoles(sbj *rbacv1.Subject) ([]*SubjectRole, e
 			return nil, err
 		}
 		sbjrs = append(sbjrs, &SubjectRole{
-			Name:       role.Name,
-			Namespace:  role.Namespace,
-			PolicyList: sbjpl,
+			BindingName:      b.Name,
+			BindingNamespace: b.Namespace,
+			BindingType:      "CRB",
+			Name:             role.Name,
+			Namespace:        role.Namespace,
+			Type:             "CR",
+			PolicyList:       sbjpl,
 		})
 	}
 	return sbjrs, nil

--- a/pkg/util/printer/converter.go
+++ b/pkg/util/printer/converter.go
@@ -22,9 +22,11 @@ const (
 	uNG2           = "✖"
 	uCheck         = "✓"
 	uCheck2        = "✔"
+	uArrow         = "⟶"
 )
 
 var bullet = aurora.Magenta(uBullet)
+var arrow = aurora.BrightCyan(uArrow)
 
 func blank2Asterisk(s string) string {
 	if strings.TrimSpace(s) == "" {

--- a/pkg/util/printer/printer.go
+++ b/pkg/util/printer/printer.go
@@ -53,8 +53,12 @@ func (p *PrettyPrinter) PrintPolicies(sbjrs []*explorer.SubjectRole) {
 		if i != 0 {
 			p.BlankLine()
 		}
-		fmt.Fprintf(p.out, "%v %v: %v/%v\n",
-			bullet, aurora.BrightCyan("Name"),
+		fmt.Fprintf(p.out, "%v [%v] %v/%v %v  [%v] %v/%v\n",
+			bullet,
+			aurora.BrightCyan(r.BindingType),
+			blank2Asterisk(r.BindingNamespace), r.BindingName,
+			arrow,
+			aurora.BrightCyan(r.Type),
 			blank2Asterisk(r.Namespace), r.Name)
 
 		if len(r.PolicyList.APIPolicies) != 0 {


### PR DESCRIPTION
Sample output:

```
ServiceAccount: default/test-user
Secrets:
• */test-user-token-mtmsz

Policies:
• [RB] default/test ⟶  [R] default/test-role
  Resource  Name  Exclude     Verbs      G L W C U P D DC         
  pods      [*]     [-]    [edit, exec]  ✔ ✖ ✖ ✖ ✖ ✖ ✖ ✖  

  Name      PRIV   RO-RootFS  Volumes  Caps  SELinux      RunAsUser      FSgroup   SUPgroup  
  test-psp  False    False      [*]    [*]   RunAsAny  MustRunAsNonRoot  RunAsAny  RunAsAny  

• [CRB] */test ⟶  [CR] */edit
  Resource                                     Name  Exclude      Verbs      G L W C U P D DC         
  bindings                                     [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  configmaps                                   [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  controllerrevisions.apps                     [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  cronjobs.batch                               [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  cronjobs.batch/status                        [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  daemonsets.apps                              [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  daemonsets.apps/status                       [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  daemonsets.extensions                        [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  daemonsets.extensions/status                 [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  deployments.apps                             [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  deployments.apps/rollback                    [*]     [-]         [-]       ✖ ✖ ✖ ✔ ✔ ✔ ✔ ✔  
  deployments.apps/scale                       [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  deployments.apps/status                      [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  deployments.extensions                       [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  deployments.extensions/rollback              [*]     [-]         [-]       ✖ ✖ ✖ ✔ ✔ ✔ ✔ ✔  
  deployments.extensions/scale                 [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  deployments.extensions/status                [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  endpoints                                    [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  events                                       [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  horizontalpodautoscalers.autoscaling         [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  horizontalpodautoscalers.autoscaling/status  [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  ingresses.extensions                         [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  ingresses.extensions/status                  [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  ingresses.networking.k8s.io                  [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  ingresses.networking.k8s.io/status           [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  jobs.batch                                   [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  jobs.batch/status                            [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  limitranges                                  [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  namespaces                                   [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  namespaces/status                            [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  networkpolicies.extensions                   [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  networkpolicies.networking.k8s.io            [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  persistentvolumeclaims                       [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  persistentvolumeclaims/status                [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  poddisruptionbudgets.policy                  [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  poddisruptionbudgets.policy/status           [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  pods                                         [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  pods/attach                                  [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  pods/exec                                    [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  pods/log                                     [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  pods/portforward                             [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  pods/proxy                                   [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  pods/status                                  [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  replicasets.apps                             [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicasets.apps/scale                       [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicasets.apps/status                      [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  replicasets.extensions                       [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicasets.extensions/scale                 [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicasets.extensions/status                [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  replicationcontrollers                       [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicationcontrollers.extensions/scale      [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicationcontrollers/scale                 [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  replicationcontrollers/status                [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  resourcequotas                               [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  resourcequotas/status                        [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  secrets                                      [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  serviceaccounts                              [*]     [-]    [impersonate]  ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  services                                     [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  services/proxy                               [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  services/status                              [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖  
  statefulsets.apps                            [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  statefulsets.apps/scale                      [*]     [-]         [-]       ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔  
  statefulsets.apps/status                     [*]     [-]         [-]       ✔ ✔ ✔ ✖ ✖ ✖ ✖ ✖ 
```