### PR TITLE
Fixes requiring namespace when namespace variable is not set

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+echo; echo "Clean up..."
+kubectl delete sa test-user
+kubectl delete psp test-psp
+kubectl delete role test-role
+kubectl delete rolebinding test
+kubectl delete clusterrolebinding test
+kubectl delete rolebinding test-group
+kubectl delete clusterrolebinding test-group

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo; echo "Creating ServiceAccount..."
-kubectl create sa test-user --dry-run -o yaml | kubectl apply -f -
+kubectl create sa test-user --dry-run=client -o yaml | kubectl apply -f -
 
 echo; echo "Creating PSP..."
 cat <<EOF | kubectl apply -f -
@@ -54,18 +54,18 @@ EOF
 echo; echo "Binding Role..."
 kubectl create rolebinding test \
         --role=test-role \
-        --serviceaccount=default:test-user --dry-run -o yaml | kubectl apply -f -
+        --serviceaccount=default:test-user --dry-run=client -o yaml | kubectl apply -f -
 
 echo; echo "Binding ClusterRole..."
-kubectl create clusterrolebinding test --clusterrole edit --serviceaccount default:test-user --dry-run -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding test --clusterrole edit --serviceaccount default:test-user --dry-run=client -o yaml | kubectl apply -f -
 
 echo; echo "Binding Role[Group]..."
 kubectl create rolebinding test-group \
         --role=test-role \
-        --group developer --dry-run -o yaml | kubectl apply -f -
+        --group developer --dry-run=client -o yaml | kubectl apply -f -
 
 echo; echo "Binding ClusterRole[Group]..."
-kubectl create clusterrolebinding test-group --clusterrole edit --group developer --dry-run -o yaml | kubectl apply -f -
+kubectl create clusterrolebinding test-group --clusterrole edit --group developer --dry-run=client -o yaml | kubectl apply -f -
 
 echo; echo "Test..."
 ./_output/kubectl-rolesum test-user

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo; echo "Creating ServiceAccount..."
-kubectl create sa test-user
+kubectl create sa test-user --dry-run -o yaml | kubectl apply -f -
 
 echo; echo "Creating PSP..."
 cat <<EOF | kubectl apply -f -
@@ -54,10 +54,23 @@ EOF
 echo; echo "Binding Role..."
 kubectl create rolebinding test \
         --role=test-role \
-        --serviceaccount=default:test-user
+        --serviceaccount=default:test-user --dry-run -o yaml | kubectl apply -f -
 
 echo; echo "Binding ClusterRole..."
-kubectl create clusterrolebinding test --clusterrole edit --serviceaccount default:test-user
+kubectl create clusterrolebinding test --clusterrole edit --serviceaccount default:test-user --dry-run -o yaml | kubectl apply -f -
+
+echo; echo "Binding Role[Group]..."
+kubectl create rolebinding test-group \
+        --role=test-role \
+        --group developer --dry-run -o yaml | kubectl apply -f -
+
+echo; echo "Binding ClusterRole[Group]..."
+kubectl create clusterrolebinding test-group --clusterrole edit --group developer --dry-run -o yaml | kubectl apply -f -
 
 echo; echo "Test..."
 ./_output/kubectl-rolesum test-user
+
+echo; echo "Test[Group]..."
+./_output/kubectl-rolesum -k Group developer
+
+./clean.sh


### PR DESCRIPTION
https://github.com/Ladicle/kubectl-rolesum/issues/29

Fixing namespace not set error, when kind is not ServiceAccount.

In this fix, when kind is Group, the summary for role will not be shown even if present.
In the current implementation, no summary will be shown for this corner case.

To allow summary for Group with role, the following line should be modified to add Group.
https://github.com/Ladicle/kubectl-rolesum/blob/master/cmd/cmd.go#L111
This PR do not fix this problem.