### PR TITLE
support verbs "*" at Role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/*
 dist/*
+_outout/*

--- a/pkg/explorer/apipolicy.go
+++ b/pkg/explorer/apipolicy.go
@@ -11,6 +11,7 @@ const (
 	VerbPatch
 	VerbDelete
 	VerbDeletionC
+	VerbAll = VerbGet | VerbList | VerbUpdate | VerbDelete | VerbDeletionC | VerbPatch | VerbCreate | VerbWatch
 )
 
 type ResourceAPIPolicy struct {
@@ -51,6 +52,8 @@ func (r *ResourceAPIPolicy) SetVerbs(verbs []string) {
 			r.APIVerbFlag |= VerbCreate
 		case "watch":
 			r.APIVerbFlag |= VerbWatch
+		case "*":
+			r.APIVerbFlag |= VerbAll
 		default:
 			r.OtherVerbs = append(r.OtherVerbs, v)
 		}


### PR DESCRIPTION
support verbs "*" at Role

fix: https://github.com/Ladicle/kubectl-rolesum/issues/33

# test case

```
cat << _EOF_ | kubectl apply -f -
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: all-pod-cm
rules:
- apiGroups:
  - ""
  resources:
  - pods
  - configmaps
  verbs:
  - "*"
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: all-pod-cm
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: all-pod-cm
subjects:
- kind: ServiceAccount
  name: default
  namespace: default
_EOF_
```

# How it will be changed

* Before

```
$ _output/kubectl-rolesum -n default default
ServiceAccount: default/default
Secrets:
• */default-token-9dhd5

Policies:
• [RB] default/all-pod-cm ⟶  [R] default/all-pod-cm
  Resource    Name  Exclude  Verbs  G L W C U P D DC
  configmaps  [*]     [-]     [-]   ✖ ✖ ✖ ✖ ✖ ✖ ✖ ✖
  pods        [*]     [-]     [-]   ✖ ✖ ✖ ✖ ✖ ✖ ✖ ✖
```

* After

```
$ _output/kubectl-rolesum -n default default
ServiceAccount: default/default
Secrets:
• */default-token-9dhd5

Policies:
• [RB] default/all-pod-cm ⟶  [R] default/all-pod-cm
  Resource    Name  Exclude  Verbs  G L W C U P D DC
  configmaps  [*]     [-]     [-]   ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔
  pods        [*]     [-]     [-]   ✔ ✔ ✔ ✔ ✔ ✔ ✔ ✔
```


