### PR TITLE
Explicitly ignore namespaced Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Options:
   -n, --namespace string       Change the namespace scope for this CLI request
   -k, --subject-kind string    Set SubjectKind to summarize (default: ServiceAccount)
   -o, --options                List of all options for this command
+  -c, --cluster-only           Ingore namespaced Roles and show only ClusterRoles
       --version                Show version for this command
 
 Use "kubectl rolesum --options" for a list of all options (applies to this command).

--- a/pkg/util/cmd/usage.go
+++ b/pkg/util/cmd/usage.go
@@ -29,6 +29,7 @@ Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "he
   -n, --namespace string       Change the namespace scope for this CLI request
   -k, --subject-kind string    Set SubjectKind to summarize (default: ServiceAccount)
   -o, --options                List of all options for this command
+  -c, --cluster-only           Ingore namespaced Roles and show only ClusterRoles
       --version                Show version for this command
 
 Use "kubectl rolesum --options" for a list of all options (applies to this command).

--- a/test.sh
+++ b/test.sh
@@ -73,4 +73,7 @@ echo; echo "Test..."
 echo; echo "Test[Group]..."
 ./_output/kubectl-rolesum -k Group developer
 
+echo; echo "Test[Group w/ ClusterOnly]..."
+./_output/kubectl-rolesum -k Group developer -c
+
 ./clean.sh


### PR DESCRIPTION
Previously in https://github.com/Ladicle/kubectl-rolesum/issues/29 assumed that only ServiceAccount will show namespace Roles. Currently it is not possible for Group/User to show namespace scoped permissions.

In this PR, I removed the implicit assumption for the Subjects, instead added a flag `--cluster-only/-c` for skipping namespace scoped resources.

It become the user's responsibility to correctly add flags accordingly during execution.

fix #31